### PR TITLE
Update rlottie.spec

### DIFF
--- a/packaging/rlottie.spec
+++ b/packaging/rlottie.spec
@@ -1,65 +1,85 @@
-Name:       lottie-player
-Summary:    rlottie Library
-Version:    0.0.1
-Release:    1
-Group:      UI Framework/Services
-License:    LGPL-2.1+ and BSD-3-Clause and MIT
-URL:        http://www.tizen.org/
-Source0:    %{name}-%{version}.tar.gz
+%define         major 0
+%define         libname %mklibname rlottie %{major}
+%define         devel %mklibname rlottie -d
+
+%define         git 20200408
+%define         rel 1
+
+Name:           rlottie
+Version:        0.0.1
+Release:        %mkrel -c %{?git:git%{git}} %{rel}
+Summary:        Platform independent standalone library that plays Lottie Animation
+Group:          System/Libraries
+License:        LGPLv2+ and BSD and MIT
+URL:            http://www.tizen.org/
+Source0:        https://github.com/Samsung/rlottie/archive/master/%{name}-%{version}%{?git:-git%{git}}.tar.gz
+
 BuildRequires:  meson
-BuildRequires:  ninja
-Requires(post): /sbin/ldconfig
-Requires(postun): /sbin/ldconfig
 
 %description
-rlottie library
+rlottie is a platform independent standalone c++ library for rendering vector
+based animations and art in realtime.
 
+Lottie loads and renders animations and vectors exported in the bodymovin JSON
+format. Bodymovin JSON can be created and exported from After Effects with
+bodymovin, Sketch with Lottie Sketch Export, and from Haiku.
 
-%package devel
-Summary:    rlottie library (devel)
-Group:      Development/Libraries
-Requires:   %{name} = %{version}-%{release}
+For the first time, designers can create and ship beautiful animations without
+an engineer painstakingly recreating it by hand. Since the animation is backed
+by JSON they are extremely small in size but can be large in complexity!
 
+%package -n %{devel}
+Summary:       Development libraries for rlottie
+Group:         System/Libraries
 
-%description devel
-rlottie library (devel)
+%description -n %{devel}
+rlottie is a platform independent standalone c++ library for rendering vector
+based animations and art in realtime.
 
+Lottie loads and renders animations and vectors exported in the bodymovin JSON
+format. Bodymovin JSON can be created and exported from After Effects with
+bodymovin, Sketch with Lottie Sketch Export, and from Haiku.
 
-%prep
-%setup -q
+For the first time, designers can create and ship beautiful animations without
+an engineer painstakingly recreating it by hand. Since the animation is backed
+by JSON they are extremely small in size but can be large in complexity!                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                
+This is the development libraries for rlottie.                                                                                                                                                                                                                                  
+                                                                                                                                                                                                                                                                                
+%package -n %{libname}                                                                                                                                                                                                                                                          
+Summary:       Platform independent standalone library that plays Lottie Animation                                                                                                                                                                                              
+Group:         System/Libraries                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                
+%description -n %{libname}                                                                                                                                                                                                                                                      
+rlottie is a platform independent standalone c++ library for rendering vector                                                                                                                                                                                                   
+based animations and art in realtime.                                                                                                                                                                                                                                           
+                                                                                                                                                                                                                                                                                
+Lottie loads and renders animations and vectors exported in the bodymovin JSON                                                                                                                                                                                                  
+format. Bodymovin JSON can be created and exported from After Effects with                                                                                                                                                                                                      
+bodymovin, Sketch with Lottie Sketch Export, and from Haiku.                                                                                                                                                                                                                    
+                                                                                                                                                                                                                                                                                
+For the first time, designers can create and ship beautiful animations without                                                                                                                                                                                                  
+an engineer painstakingly recreating it by hand. Since the animation is backed                                                                                                                                                                                                  
+by JSON they are extremely small in size but can be large in complexity!                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                
+%prep                                                                                                                                                                                                                                                                           
+%autosetup -n %{name}-master                                                                                                                                                                                                                                                    
+                                                                                                                                                                                                                                                                                
+%build                                                                                                                                                                                                                                                                          
+%meson                                                                                                                                                                                                                                                                          
+                                                                                                                                                                                                                                                                                
+%install                                                                                                                                                                                                                                                                        
+%meson_install
 
-
-%build
-
-export DESTDIR=%{buildroot}
-
-export CXXFLAGS+=" -std=gnu++14"
-
-meson setup \
-                --prefix /usr \
-                --libdir %{_libdir} \
-                builddir 2>&1
-ninja \
-      -C builddir \
-      -j %(echo "`/usr/bin/getconf _NPROCESSORS_ONLN`")
-
-%install
-
-export DESTDIR=%{buildroot}
-
-ninja -C builddir install
-
-%files
-%defattr(-,root,root,-)
-%{_libdir}/librlottie.so.*
-%{_libdir}/librlottie-image-loader.so*
-%manifest packaging/rlottie.manifest
-%license COPYING licenses/COPYING*
-
-%files devel
-%defattr(-,root,root,-)
-%{_includedir}/*.h
-%{_libdir}/librlottie.so
-%{_libdir}/librlottie-image-loader.so
-
+%files -n %{devel}                                                                                                                                                                                                                                                              
+%{_includedir}/rlottie.h
+%{_includedir}/rlottie_capi.h
+%{_includedir}/rlottiecommon.h
 %{_libdir}/pkgconfig/rlottie.pc
+%{_libdir}/librlottie.so
+
+%files -n %{libname}
+%license COPYING
+%doc README.md AUTHORS
+%{_libdir}/librlottie-image-loader.so
+%{_libdir}/librlottie.so.%{major}{,.*}


### PR DESCRIPTION
This change comes from Mageia and has a lot more information and better library setup.

It fetches the latest git master from Github and builds a package that reflects that it's not a release.